### PR TITLE
Allowed each char creation tab to display existing character info

### DIFF
--- a/src/app/char-creation-appearance-tab/char-creation-appearance-tab.component.ts
+++ b/src/app/char-creation-appearance-tab/char-creation-appearance-tab.component.ts
@@ -13,6 +13,8 @@ export class CharCreationAppearanceTabComponent implements OnInit {
 
   currentChar: charObject = new charObject;
 
+  //updates the character's age information (in the char's appearance object)
+  //creates a new appearance object if it doesn't already exist
   updateAge() {
     if(this.currentChar.appearance == null) {
       this.currentChar.appearance = new appearanceObject;
@@ -24,6 +26,8 @@ export class CharCreationAppearanceTabComponent implements OnInit {
     sessionStorage.setItem('currentChar', JSON.stringify(this.currentChar));
   }
 
+  //updates the character's height information (in the char's appearance object)
+  //creates a new appearance object if it doesn't already exist
   updateHeight() {
     if(this.currentChar.appearance == null) {
       this.currentChar.appearance = new appearanceObject;
@@ -35,6 +39,8 @@ export class CharCreationAppearanceTabComponent implements OnInit {
     sessionStorage.setItem('currentChar', JSON.stringify(this.currentChar));
   }
 
+  //updates the character's weight information (in the char's appearance object)
+  //creates a new appearance object if it doesn't already exist
   updateWeight() {
     if(this.currentChar.appearance == null) {
       this.currentChar.appearance = new appearanceObject;
@@ -46,6 +52,8 @@ export class CharCreationAppearanceTabComponent implements OnInit {
     sessionStorage.setItem('currentChar', JSON.stringify(this.currentChar));
   }
 
+  //updates the character's eyes information (in the char's appearance object)
+  //creates a new appearance object if it doesn't already exist
   updateEyes() {
     if(this.currentChar.appearance == null) {
       this.currentChar.appearance = new appearanceObject;
@@ -57,6 +65,8 @@ export class CharCreationAppearanceTabComponent implements OnInit {
     sessionStorage.setItem('currentChar', JSON.stringify(this.currentChar));
   }
 
+  //updates the character's skin information (in the char's appearance object)
+  //creates a new appearance object if it doesn't already exist
   updateSkin() {
     if(this.currentChar.appearance == null) {
       this.currentChar.appearance = new appearanceObject;
@@ -68,6 +78,8 @@ export class CharCreationAppearanceTabComponent implements OnInit {
     sessionStorage.setItem('currentChar', JSON.stringify(this.currentChar));
   }
 
+  //updates the character's hair information (in the char's appearance object)
+  //creates a new appearance object if it doesn't already exist
   updateHair() {
     if(this.currentChar.appearance == null) {
       this.currentChar.appearance = new appearanceObject;
@@ -79,6 +91,8 @@ export class CharCreationAppearanceTabComponent implements OnInit {
     sessionStorage.setItem('currentChar', JSON.stringify(this.currentChar));
   }
 
+  //updates the character's additional appearance notes (in the char's appearance object)
+  //creates a new appearance object if it doesn't already exist
   updateAdditionalNotes() {
     if(this.currentChar.appearance == null) {
       this.currentChar.appearance = new appearanceObject;
@@ -90,9 +104,42 @@ export class CharCreationAppearanceTabComponent implements OnInit {
     sessionStorage.setItem('currentChar', JSON.stringify(this.currentChar));
   }
 
+  //takes in the current character object and (as relevant) populates viewable fields with existing character info
   ngOnInit(): void {
     this.currentChar = JSON.parse(String(sessionStorage.getItem('currentChar')));
     console.log(this.currentChar);
+
+    //populates fields if the info is already present in currentChar
+    //checks to make sure the info exists first to prevent nullpointerexception
+    if(this.currentChar.appearance) {
+      if(this.currentChar.appearance.age) {
+        (document.getElementById("charAge") as HTMLInputElement).value = this.currentChar.appearance.age;
+      }
+
+      if(this.currentChar.appearance.height) {
+        (document.getElementById("charHeight") as HTMLInputElement).value = this.currentChar.appearance.height;
+      }
+
+      if(this.currentChar.appearance.weight) {
+        (document.getElementById("charWeight") as HTMLInputElement).value = this.currentChar.appearance.weight;
+      }
+
+      if(this.currentChar.appearance.eyes) {
+        (document.getElementById("charEyes") as HTMLInputElement).value = this.currentChar.appearance.eyes;
+      }
+
+      if(this.currentChar.appearance.skin) {
+        (document.getElementById("charSkin") as HTMLInputElement).value = this.currentChar.appearance.skin;
+      }
+
+      if(this.currentChar.appearance.hair) {
+        (document.getElementById("charHair") as HTMLInputElement).value = this.currentChar.appearance.hair;
+      }
+
+      if(this.currentChar.appearance.otherNotes) {
+        (document.getElementById("charAppearanceNotes") as HTMLInputElement).value = this.currentChar.appearance.otherNotes;
+      }
+    }
   }
 
 }

--- a/src/app/char-creation-backstory-tab/char-creation-backstory-tab.component.ts
+++ b/src/app/char-creation-backstory-tab/char-creation-backstory-tab.component.ts
@@ -12,6 +12,7 @@ export class CharCreationBackstoryTabComponent implements OnInit {
 
   currentChar: charObject = new charObject;
 
+  //updates the character's backstory property
   updateBackstory() {
     this.currentChar.backstory = (document.getElementById("charBackstory") as HTMLInputElement)?.value;
     console.log(this.currentChar);
@@ -19,9 +20,15 @@ export class CharCreationBackstoryTabComponent implements OnInit {
     sessionStorage.setItem('currentChar', JSON.stringify(this.currentChar));
   }
 
+  //takes in the current character object and (if it exists) uses its existing backstory info to populate the viewable field
   ngOnInit(): void {
     this.currentChar = JSON.parse(String(sessionStorage.getItem('currentChar')));
     console.log(this.currentChar);
+
+    //populates fields if the info is already present in currentChar
+    if(this.currentChar.backstory) {
+      (document.getElementById("charBackstory") as HTMLInputElement).value = this.currentChar.backstory;
+    }
   }
 
 }

--- a/src/app/char-creation-class-tab/char-creation-class-tab.component.html
+++ b/src/app/char-creation-class-tab/char-creation-class-tab.component.html
@@ -13,11 +13,14 @@
         <option value="etc">etc</option>
     </select>
 
-    <h4>Features (placeholders):</h4>
-    <ul>
-        <li>feature1</li>
-        <li>feature2</li>
-    </ul>
+    <h4>Features:</h4>
+
+    <div *ngFor="let feat of charClassesInfo[i].levelFeatures">
+        <p>{{feat[0]}}: </p>
+        <p *ngFor="let line of feat[1]">{{line}}</p>
+
+        <br>
+    </div>
 
     <div *ngIf="charClass == charClasses[0]">
         <h4>Proficiencies:</h4>
@@ -30,7 +33,7 @@
         <h4>Skills (Choose {{charClassesInfo[i].skillProficiencyCount}}):</h4>
 
         <div *ngFor="let profOption of charClassesInfo[i].userProficienciesOptions">
-            <input type="checkbox" id="skillProfOptions" value={{profOption[0]}} (click)="updateClassProficiency(profOption[0], profOption[1], i)">
+            <input type="checkbox" id="skillProfOptions" [attr.checked]="(classesCheckboxes(profOption[0], currentChar.classes[i].chosenProficiencyIndex)) ? true : null" value={{profOption[0]}} (click)="updateClassProficiency(profOption[0], profOption[1], i)">
             <label for="skillProfOptions"> {{profOption[1]}}</label><br>
         </div>
     </div>

--- a/src/app/char-creation-class-tab/classInfo.ts
+++ b/src/app/char-creation-class-tab/classInfo.ts
@@ -7,6 +7,8 @@ export class classInfo {
   classLevel: number = 0;
   hitDie: number = 0;
   skillProficiencies?: any[][];
+  levelFeatures: string[][] = [];
+  test: boolean = false;
   skillProficiencyCount?: number;
   startingEquipment?: any[][];
 

--- a/src/app/char-creation-equipment-tab/char-creation-equipment-tab.component.css
+++ b/src/app/char-creation-equipment-tab/char-creation-equipment-tab.component.css
@@ -2,6 +2,9 @@ div {
     border: solid black 2px;
     padding: 10px;
     margin: 10px;
+}
+
+.container {
     width: 30%;
 }
 

--- a/src/app/char-creation-equipment-tab/char-creation-equipment-tab.component.html
+++ b/src/app/char-creation-equipment-tab/char-creation-equipment-tab.component.html
@@ -1,8 +1,6 @@
 <h2>Equipment</h2>
 
-<!--NOTE: CHOICE SELECTIONS ARE TEMPORARILY HARD-CODED-->
-<!--FOR EXAMPLE: 1 GLAIVE IS ADDED INSTEAD OF USER BEING PRESENTED WITH ANY MARTIAL MELEE WEAPON CHOICE-->
-<div *ngIf="startingClass == 'barbarian' && currentChar.startingEquipmentSelected == false">
+<div *ngIf="startingClass == 'barbarian' && currentChar.startingEquipmentSelected == false" class="container">
     <h4>Starting Equipment:</h4>
 
     <ul>
@@ -13,23 +11,43 @@
     <p>Choose between...</p>
 
     <div>
-        <input type="radio" id="1a" name="classEquipment1" value="1a" (click)="addItems([['greataxe', 1]])">
+        <input type="radio" id="1a" name="classEquipment1" value="1a" 
+            [attr.checked]="(chosenOptions.includes('1a')) ? true : null" (click)="addItems([['greataxe', 1]]); updateSelected('1a')">
         <label for="1a">(a) A greataxe</label><br>
 
-        <input type="radio" id="1b" name="classEquipment1" value="1b" (click)="addItems([['glaive', 1]])"> <!--EQUIPMENT TYPE SELECTOR-->
+        <input type="radio" id="1b" name="classEquipment1" value="1b" 
+            [attr.checked]="(chosenOptions.includes('1b')) ? true : null" (click)="revealCategory('barb-1b'); updateSelected('1b')">
         <label for="1b">(b) Any martial melee weapon</label><br>
+
+        <div id="barb-1b" style="display: none">
+            <select name="barb-1b-1" id="barb-1b-1" (change)="addItemsFromSelect('barb-1b-1')">
+                <option selected value="none">Select</option>
+                <option *ngFor="let item of martial_melee_weapons" [value]="item[0]">{{item[1]}}</option>
+            </select>
+        </div>
+        
     </div>
 
     <div>
-        <input type="radio" id="2a" name="classEquipment2" value="2a" (click)="addItems([['handaxe', 2]])">
+        <input type="radio" id="2a" name="classEquipment2" value="2a" 
+            [attr.checked]="(chosenOptions.includes('2a')) ? true : null" (click)="addItems([['handaxe', 2]]); updateSelected('2a')">
         <label for="2a">(a) Two handaxes</label><br>
 
-        <input type="radio" id="2b" name="classEquipment2" value="2b" (click)="addItems([['club', 1]])"> <!--EQUIPMENT TYPE SELECTOR-->
+        <input type="radio" id="2b" name="classEquipment2" value="2b" 
+            [attr.checked]="(chosenOptions.includes('2b')) ? true : null" (click)="revealCategory('barb-2b'); updateSelected('2b')">
         <label for="2b">(b) Any simple weapon</label><br>
+
+        <div id="barb-2b" style="display: none">
+            <select name="barb-2b-1" id="barb-2b-1" (change)="addItemsFromSelect('barb-2b-1')">
+                <option selected value="none">Select</option>
+                <option *ngFor="let item of simple_weapons" [value]="item[0]">{{item[1]}}</option>
+            </select>
+        </div>
+        
     </div>
 </div>
 
-<div *ngIf="startingClass == 'bard' && currentChar.startingEquipmentSelected == false">
+<div *ngIf="startingClass == 'bard' && currentChar.startingEquipmentSelected == false" class="container">
     <h4>Starting Equipment:</h4>
 
     <ul>
@@ -40,34 +58,55 @@
     <p>Choose between...</p>
 
     <div>
-        <input type="radio" id="1a" name="classEquipment1" value="1a" (click)="addItems([['rapier', 1]])">
+        <input type="radio" id="1a" name="classEquipment1" value="1a" 
+            [attr.checked]="(chosenOptions.includes('1a')) ? true : null" (click)="addItems([['rapier', 1]]); updateSelected('1a')">
         <label for="1a">(a) A rapier</label><br>
 
-        <input type="radio" id="1b" name="classEquipment1" value="1b" (click)="addItems([['longsword', 1]])">
+        <input type="radio" id="1b" name="classEquipment1" value="1b" 
+            [attr.checked]="(chosenOptions.includes('1b')) ? true : null" (click)="addItems([['longsword', 1]]); updateSelected('1b')">
         <label for="1b">(b) A longsword</label><br>
 
-        <input type="radio" id="1c" name="classEquipment1" value="1c" (click)="addItems([['club', 1]])"> <!--EQUIPMENT TYPE SELECTOR-->
+        <input type="radio" id="1c" name="classEquipment1" value="1c" 
+            [attr.checked]="(chosenOptions.includes('1c')) ? true : null" (click)="revealCategory('bard-1c'); updateSelected('1c')">
         <label for="1c">(c) Any simple weapon</label><br>
+
+        <div id="bard-1c" style="display: none">
+            <select name="bard-1c-1" id="bard-1c-1" (change)="addItemsFromSelect('bard-1c-1')">
+                <option selected value="none">Select</option>
+                <option *ngFor="let item of simple_weapons" [value]="item[0]">{{item[1]}}</option>
+            </select>
+        </div>
     </div>
 
     <div>
-        <input type="radio" id="2a" name="classEquipment2" value="2a" (click)="addItems([['diplomats-pack', 1]])">
+        <input type="radio" id="2a" name="classEquipment2" value="2a" 
+            [attr.checked]="(chosenOptions.includes('2a')) ? true : null" (click)="addItems([['diplomats-pack', 1]]); updateSelected('2a')">
         <label for="2a">(a) A diplomat's pack</label><br>
 
-        <input type="radio" id="2b" name="classEquipment2" value="2b" (click)="addItems([['entertainers-pack', 1]])">
+        <input type="radio" id="2b" name="classEquipment2" value="2b" 
+            [attr.checked]="(chosenOptions.includes('2b')) ? true : null" (click)="addItems([['entertainers-pack', 1]]); updateSelected('2b')">
         <label for="2b">(b) An entertainer's pack</label><br>
     </div>
 
     <div>
-        <input type="radio" id="3a" name="classEquipment3" value="3a" (click)="addItems([['lute', 1]])">
+        <input type="radio" id="3a" name="classEquipment3" value="3a" 
+            [attr.checked]="(chosenOptions.includes('3a')) ? true : null" (click)="addItems([['lute', 1]]); updateSelected('3a')">
         <label for="3a">(a) A lute</label><br>
 
-        <input type="radio" id="3b" name="classEquipment3" value="3b" (click)="addItems([['drum', 1]])"> <!--EQUIPMENT TYPE SELECTOR-->
+        <input type="radio" id="3b" name="classEquipment3" value="3b" 
+            [attr.checked]="(chosenOptions.includes('3b')) ? true : null" (click)="revealCategory('bard-3b'); updateSelected('3b')">
         <label for="3b">(b) Any other musical instrument</label><br>
+
+        <div id="bard-3b" style="display: none">
+            <select name="bard-3b-1" id="bard-3b-1" (change)="addItemsFromSelect('bard-3b-1')">
+                <option selected value="none">Select</option>
+                <option *ngFor="let item of musical_instruments" [value]="item[0]">{{item[1]}}</option>
+            </select>
+        </div>
     </div>
 </div>
 
-<div *ngIf="startingClass == 'cleric' && currentChar.startingEquipmentSelected == false">
+<div *ngIf="startingClass == 'cleric' && currentChar.startingEquipmentSelected == false" class="container">
     <h4>Starting Equipment:</h4>
 
     <ul>
@@ -77,56 +116,66 @@
     <p>Choose between...</p>
 
     <div>
-        <input type="radio" id="1a" name="classEquipment1" value="1a" (click)="addItems([['mace', 1]])">
+        <input type="radio" id="1a" name="classEquipment1" value="1a" 
+            [attr.checked]="(chosenOptions.includes('1a')) ? true : null" (click)="addItems([['mace', 1]]); updateSelected('1a')">
         <label for="1a">(a) A mace</label><br>
 
-        <input type="radio" id="1b" name="classEquipment1" value="1b" (click)="addItems([['warhammer', 1]])">
+        <input type="radio" id="1b" name="classEquipment1" value="1b" 
+            [attr.checked]="(chosenOptions.includes('1b')) ? true : null" (click)="addItems([['warhammer', 1]]); updateSelected('1b')">
         <label for="1b">(b) A warhammer</label><br>
     </div>
 
     <div>
-        <input type="radio" id="2a" name="classEquipment2" value="2a" (click)="addItems([['scale-mail', 1]])">
+        <input type="radio" id="2a" name="classEquipment2" value="2a" 
+            [attr.checked]="(chosenOptions.includes('2a')) ? true : null" (click)="addItems([['scale-mail', 1]]); updateSelected('2a')">
         <label for="2a">(a) Scale mail</label><br>
 
-        <input type="radio" id="2b" name="classEquipment2" value="2b" (click)="addItems([['leather-armor', 1]])">
+        <input type="radio" id="2b" name="classEquipment2" value="2b" 
+            [attr.checked]="(chosenOptions.includes('2b')) ? true : null" (click)="addItems([['leather-armor', 1]]); updateSelected('2b')">
         <label for="2b">(b) Leather armor</label><br>
 
-        <input type="radio" id="2c" name="classEquipment2" value="2c" (click)="addItems([['chain-mail', 1]])">
+        <input type="radio" id="2c" name="classEquipment2" value="2c" 
+            [attr.checked]="(chosenOptions.includes('2c')) ? true : null" (click)="addItems([['chain-mail', 1]]); updateSelected('2c')">
         <label for="2c">(c) Chain mail</label><br>
     </div>
 
     <div>
-        <input type="radio" id="3a" name="classEquipment3" value="3a" (click)="addItems([['crossbow-light', 1], ['crossbow-bolt', 20]])">
+        <input type="radio" id="3a" name="classEquipment3" value="3a" 
+            [attr.checked]="(chosenOptions.includes('3a')) ? true : null" (click)="addItems([['crossbow-light', 1], ['crossbow-bolt', 20]]); updateSelected('3a')">
         <label for="3a">(a) A light crossbow and 20 bolts</label><br>
 
-        <input type="radio" id="3b" name="classEquipment3" value="3b" (click)="addItems([['club', 1]]); threeB = true;"> <!--EQUIPMENT TYPE SELECTOR-->
+        <input type="radio" id="3b" name="classEquipment3" value="3b" 
+            [attr.checked]="(chosenOptions.includes('3b')) ? true : null" (click)="revealCategory('cleric-3b'); updateSelected('3b')">
         <label for="3b">(b) Any simple weapon</label><br>
 
-        <select name="simpleWeapon" id="simpleWeapon" *ngIf="threeB" (change)="addItems([[]])">
-            <option selected>Select</option>
-            <option *ngFor="let simple of simple_weapons" [value]="simple[0]">{{simple[1]}}</option>
-        </select> 
+        <div id="cleric-3b" style="display: none">
+            <select name="cleric-3b-1" id="cleric-3b-1" (change)="addItemsFromSelect('cleric-3b-1')">
+                <option selected value="none">Select</option>
+                <option *ngFor="let item of simple_weapons" [value]="item[0]">{{item[1]}}</option>
+            </select>
+        </div>
     </div>
 
     <div>
-        <input type="radio" id="4a" name="classEquipment4" value="4a" (click)="addItems([['priests-pack', 1]])">
+        <input type="radio" id="4a" name="classEquipment4" value="4a" 
+            [attr.checked]="(chosenOptions.includes('4a')) ? true : null" (click)="addItems([['priests-pack', 1]]); updateSelected('4a')">
         <label for="4a">(a) A priest's pack</label><br>
 
-        <input type="radio" id="4b" name="classEquipment4" value="4b" (click)="addItems([['explorers-pack', 1]])">
+        <input type="radio" id="4b" name="classEquipment4" value="4b" 
+            [attr.checked]="(chosenOptions.includes('4b')) ? true : null" (click)="addItems([['explorers-pack', 1]]); updateSelected('4b')">
         <label for="4b">(b) An explorer's pack</label><br>
     </div>
 
     <div>
-        <label for="holySymbol">A holy symbol: </label>
-        <!--TODO: MAKE NEW ADDITEMS METHOD FOR SELECT OPTIONS-->
-        <select name="holySymbol" id="holySymbol" (change)="addItems([[]])">
-            <option selected>Select</option>
-            <option *ngFor="let holy of holy_symbols" [value]="holy[0]">{{holy[1]}}</option>
-        </select> <!--EQUIPMENT TYPE SELECTOR-->
+        <label for="cleric-holySymbol">A holy symbol: </label>
+        <select name="cleric-holySymbol" id="cleric-holySymbol" (change)="addItemsFromSelect('cleric-holySymbol')">
+            <option selected value="none">Select</option>
+            <option *ngFor="let item of holy_symbols" [value]="item[0]">{{item[1]}}</option>
+        </select>
     </div>
 </div>
 
-<div *ngIf="startingClass == 'druid' && currentChar.startingEquipmentSelected == false">
+<div *ngIf="startingClass == 'druid' && currentChar.startingEquipmentSelected == false" class="container">
     <h4>Starting Equipment:</h4>
 
     <ul>
@@ -137,66 +186,115 @@
     <p>Choose between...</p>
 
     <div>
-        <input type="radio" id="1a" name="classEquipment1" value="1a" (click)="addItems([['shield', 1]])">
+        <input type="radio" id="1a" name="classEquipment1" value="1a" 
+            [attr.checked]="(chosenOptions.includes('1a')) ? true : null" (click)="addItems([['shield', 1]]); updateSelected('1a')">
         <label for="1a">(a) A wooden shield</label><br>
 
-        <input type="radio" id="1b" name="classEquipment1" value="1b" (click)="addItems([['club', 1]])"> <!--EQUIPMENT TYPE SELECTOR-->
+        <input type="radio" id="1b" name="classEquipment1" value="1b" 
+            [attr.checked]="(chosenOptions.includes('1b')) ? true : null" (click)="revealCategory('druid-1b'); updateSelected('1b')">
         <label for="1b">(b) Any simple weapon</label><br>
+
+        <div id="druid-1b" style="display: none">
+            <select name="druid-1b-1" id="druid-1b-1" (change)="addItemsFromSelect('druid-1b-1')">
+                <option selected value="none">Select</option>
+                <option *ngFor="let item of simple_weapons" [value]="item[0]">{{item[1]}}</option>
+            </select>
+        </div>
     </div>
 
     <div>
-        <input type="radio" id="2a" name="classEquipment2" value="2a" (click)="addItems([['scimitar', 1]])">
+        <input type="radio" id="2a" name="classEquipment2" value="2a" 
+            [attr.checked]="(chosenOptions.includes('2a')) ? true : null" (click)="addItems([['scimitar', 1]]); updateSelected('2a')">
         <label for="2a">(a) A scimitar</label><br>
 
-        <input type="radio" id="2b" name="classEquipment2" value="2b" (click)="addItems([['club', 1]])"> <!--EQUIPMENT TYPE SELECTOR-->
+        <input type="radio" id="2b" name="classEquipment2" value="2b" 
+            [attr.checked]="(chosenOptions.includes('2b')) ? true : null" (click)="revealCategory('druid-2b'); updateSelected('2b')">
         <label for="2b">(b) Any simple melee weapon</label><br>
+
+        <div id="druid-2b" style="display: none">
+            <select name="druid-2b-1" id="druid-2b-1" (change)="addItemsFromSelect('druid-2b-1')">
+                <option selected value="none">Select</option>
+                <option *ngFor="let item of simple_melee_weapons" [value]="item[0]">{{item[1]}}</option>
+            </select>
+        </div>
     </div>
 
     <div>
-        <input type="radio" id="3a" name="classEquipment3" value="3a"> <!--EQUIPMENT TYPE SELECTOR-->
-        <label for="3a">A druidic focus</label><br>
+        <label for="druid-druidicFocus">A druidic focus</label><br>
+        <select name="druid-druidicFocus" id="druid-druidicFocus" (change)="addItemsFromSelect('druid-druidicFocus')">
+            <option selected value="none">Select</option>
+            <option *ngFor="let item of druidic_foci" [value]="item[0]">{{item[1]}}</option>
+        </select>
     </div>
 </div>
 
-<div *ngIf="startingClass == 'fighter' && currentChar.startingEquipmentSelected == false">
+<div *ngIf="startingClass == 'fighter' && currentChar.startingEquipmentSelected == false" class="container">
     <h4>Starting Equipment:</h4>
 
     <p>Choose between...</p>
 
     <div>
-        <input type="radio" id="1a" name="classEquipment1" value="1a" (click)="addItems([['chain-mail', 1]])">
+        <input type="radio" id="1a" name="classEquipment1" value="1a" 
+            [attr.checked]="(chosenOptions.includes('1a')) ? true : null" (click)="addItems([['chain-mail', 1]]); updateSelected('1a')">
         <label for="1a">(a) Chain mail</label><br>
 
-        <input type="radio" id="1b" name="classEquipment1" value="1b" (click)="addItems([['leather-armor', 1], ['longbow', 1], ['arrow', 20]])">
+        <input type="radio" id="1b" name="classEquipment1" value="1b" 
+            [attr.checked]="(chosenOptions.includes('1b')) ? true : null" (click)="addItems([['leather-armor', 1], ['longbow', 1], ['arrow', 20]]); updateSelected('1b')">
         <label for="1b">(b) Leather armor, a longbow, and 20 arrows</label><br>
     </div>
 
     <div>
-        <input type="radio" id="2a" name="classEquipment2" value="2a" (click)="addItems([['shield', 1]])"> <!--EQUIPMENT TYPE SELECTOR-->
+        <input type="radio" id="2a" name="classEquipment2" value="2a" 
+            [attr.checked]="(chosenOptions.includes('2a')) ? true : null" (click)="addItems([['shield', 1]]); revealCategory('fighter-2a'); updateSelected('2a')">
         <label for="2a">(a) A martial weapon and a shield</label><br>
 
-        <input type="radio" id="2b" name="classEquipment2" value="2b"> <!--EQUIPMENT TYPE SELECTOR-->
+        <div id="fighter-2a" style="display: none">
+            <select name="fighter-2a-1" id="fighter-2a-1" (change)="addItemsFromSelect('fighter-2a-1')">
+                <option selected value="none">Select</option>
+                <option *ngFor="let item of martial_weapons" [value]="item[0]">{{item[1]}}</option>
+            </select>
+        </div>
+
+        <input type="radio" id="2b" name="classEquipment2" value="2b" 
+            [attr.checked]="(chosenOptions.includes('2b')) ? true : null" (click)="revealCategory('fighter-2b'); updateSelected('2b')">
         <label for="2b">(b) Two martial weapons</label><br>
+
+        <div id="fighter-2b" style="display: none">
+            <select name="fighter-2b-1" id="fighter-2b-1" (change)="addItemsFromSelect('fighter-2b-1')">
+                <option selected value="none">Select</option>
+                <option *ngFor="let item of martial_weapons" [value]="item[0]">{{item[1]}}</option>
+            </select>
+
+            <select name="fighter-2b-2" id="fighter-2b-2" (change)="addItemsFromSelect('fighter-2b-2')">
+                <option selected value="none">Select</option>
+                <option *ngFor="let item of martial_weapons" [value]="item[0]">{{item[1]}}</option>
+            </select>
+        </div>
+
     </div>
 
     <div>
-        <input type="radio" id="3a" name="classEquipment3" value="3a" (click)="addItems([['crossbow-light', 1], ['crossbow-bolt', 20]])">
+        <input type="radio" id="3a" name="classEquipment3" value="3a" 
+            [attr.checked]="(chosenOptions.includes('3a')) ? true : null" (click)="addItems([['crossbow-light', 1], ['crossbow-bolt', 20]]); updateSelected('3a')">
         <label for="3a">(a) A light crossbow and 20 bolts</label><br>
 
-        <input type="radio" id="3b" name="classEquipment3" value="3b" (click)="addItems([['handaxe', 2]])">
+        <input type="radio" id="3b" name="classEquipment3" value="3b" 
+            [attr.checked]="(chosenOptions.includes('3b')) ? true : null" (click)="addItems([['handaxe', 2]]); updateSelected('3b')">
         <label for="3b">(b) Two handaxes</label><br>
     </div>
 
     <div>
-        <input type="radio" id="4a" name="classEquipment4" value="4a" (click)="addItems([['dungeoneers-pack', 1]])">
+        <input type="radio" id="4a" name="classEquipment4" value="4a" 
+            [attr.checked]="(chosenOptions.includes('4a')) ? true : null" (click)="addItems([['dungeoneers-pack', 1]]); updateSelected('4a')">
         <label for="4a">(a) A dungeoneer's pack</label><br>
 
-        <input type="radio" id="4b" name="classEquipment4" value="4b" (click)="addItems([['explorers-pack', 1]])">
+        <input type="radio" id="4b" name="classEquipment4" value="4b" 
+            [attr.checked]="(chosenOptions.includes('4b')) ? true : null" (click)="addItems([['explorers-pack', 1]]); updateSelected('4b')">
         <label for="4b">(b) An explorer's pack</label><br>
     </div>
 </div>
 
-<div *ngIf="startingClass == 'monk' && currentChar.startingEquipmentSelected == false">
+<div *ngIf="startingClass == 'monk' && currentChar.startingEquipmentSelected == false" class="container">
     <h4>Starting Equipment:</h4>
 
     <ul>
@@ -206,23 +304,34 @@
     <p>Choose between...</p>
 
     <div>
-        <input type="radio" id="1a" name="classEquipment1" value="1a" (click)="addItems([['shortsword', 1]])">
+        <input type="radio" id="1a" name="classEquipment1" value="1a" 
+            [attr.checked]="(chosenOptions.includes('1a')) ? true : null" (click)="addItems([['shortsword', 1]]); updateSelected('1a')">
         <label for="1a">(a) A shortsword</label><br>
 
-        <input type="radio" id="1b" name="classEquipment1" value="1b" (click)="addItems([['club', 1]])"> <!--EQUIPMENT TYPE SELECTOR-->
+        <input type="radio" id="1b" name="classEquipment1" value="1b" 
+            [attr.checked]="(chosenOptions.includes('1b')) ? true : null" (click)="revealCategory('monk-1b'); updateSelected('1b')">
         <label for="1b">(b) Any simple weapon</label><br>
+
+        <div id="monk-1b" style="display: none">
+            <select name="monk-1b-1" id="monk-1b-1" (change)="addItemsFromSelect('monk-1b-1')">
+                <option selected value="none">Select</option>
+                <option *ngFor="let item of simple_weapons" [value]="item[0]">{{item[1]}}</option>
+            </select>
+        </div>
     </div>
 
     <div>
-        <input type="radio" id="2a" name="classEquipment2" value="2a" (click)="addItems([['dungeoneers-pack', 1]])">
+        <input type="radio" id="2a" name="classEquipment2" value="2a" 
+            [attr.checked]="(chosenOptions.includes('2a')) ? true : null" (click)="addItems([['dungeoneers-pack', 1]]); updateSelected('2a')">
         <label for="2a">(a) A dungeoneer's pack</label><br>
 
-        <input type="radio" id="2b" name="classEquipment2" value="2b" (click)="addItems([['explorers-pack', 1]])">
+        <input type="radio" id="2b" name="classEquipment2" value="2b" 
+            [attr.checked]="(chosenOptions.includes('2b')) ? true : null" (click)="addItems([['explorers-pack', 1]]); updateSelected('2b')">
         <label for="2b">(b) An explorer's pack</label><br>
     </div>
 </div>
 
-<div *ngIf="startingClass == 'paladin' && currentChar.startingEquipmentSelected == false">
+<div *ngIf="startingClass == 'paladin' && currentChar.startingEquipmentSelected == false" class="container">
     <h4>Starting Equipment:</h4>
 
     <ul>
@@ -232,36 +341,71 @@
     <p>Choose between...</p>
 
     <div>
-        <input type="radio" id="1a" name="classEquipment1" value="1a" (click)="addItems([['shield', 1]])"> <!--EQUIPMENT TYPE SELECTOR-->
+        <input type="radio" id="1a" name="classEquipment1" value="1a" 
+            [attr.checked]="(chosenOptions.includes('1a')) ? true : null" (click)="addItems([['shield', 1]]); revealCategory('paladin-1a'); updateSelected('1a')">
         <label for="1a">(a) A martial weapon and a shield</label><br>
 
-        <input type="radio" id="1b" name="classEquipment1" value="1b"> <!--EQUIPMENT TYPE SELECTOR-->
+        <div id="paladin-1a" style="display: none">
+            <select name="paladin-1a-1" id="paladin-1a-1" (change)="addItemsFromSelect('paladin-1a-1')">
+                <option selected value="none">Select</option>
+                <option *ngFor="let item of martial_weapons" [value]="item[0]">{{item[1]}}</option>
+            </select>
+        </div>
+
+        <input type="radio" id="1b" name="classEquipment1" value="1b" 
+            [attr.checked]="(chosenOptions.includes('1b')) ? true : null" (click)="revealCategory('paladin-1b'); updateSelected('1b')">
         <label for="1b">(b) Two martial weapons</label><br>
+
+        <div id="paladin-1b" style="display: none">
+            <select name="paladin-1b-1" id="paladin-1b-1" (change)="addItemsFromSelect('paladin-1b-1')">
+                <option selected value="none">Select</option>
+                <option *ngFor="let item of martial_weapons" [value]="item[0]">{{item[1]}}</option>
+            </select>
+
+            <select name="paladin-1bb-2" id="paladin-1b-2" (change)="addItemsFromSelect('paladin-1b-2')">
+                <option selected value="none">Select</option>
+                <option *ngFor="let item of martial_weapons" [value]="item[0]">{{item[1]}}</option>
+            </select>
+        </div>
     </div>
 
     <div>
-        <input type="radio" id="2a" name="classEquipment2" value="2a" (click)="addItems([['javelin', 5]])">
+        <input type="radio" id="2a" name="classEquipment2" value="2a" 
+            [attr.checked]="(chosenOptions.includes('2a')) ? true : null" (click)="addItems([['javelin', 5]]); updateSelected('2a')">
         <label for="2a">(a) 5 javelins</label><br>
 
-        <input type="radio" id="2b" name="classEquipment2" value="2b" (click)="addItems([['club', 1]])"> <!--EQUIPMENT TYPE SELECTOR-->
+        <input type="radio" id="2b" name="classEquipment2" value="2b" 
+            [attr.checked]="(chosenOptions.includes('2b')) ? true : null" (click)="revealCategory('paladin-2b'); updateSelected('2b')">
         <label for="2b">(b) Any simple melee weapon</label><br>
+
+        <div id="paladin-2b" style="display: none">
+            <select name="paladin-2b-1" id="paladin-2b-1" (change)="addItemsFromSelect('paladin-2b-1')">
+                <option selected value="none">Select</option>
+                <option *ngFor="let item of simple_melee_weapons" [value]="item[0]">{{item[1]}}</option>
+            </select>
+        </div>
     </div>
 
     <div>
-        <input type="radio" id="3a" name="classEquipment3" value="3a" (click)="addItems([['priests-pack', 1]])">
+        <input type="radio" id="3a" name="classEquipment3" value="3a" 
+            [attr.checked]="(chosenOptions.includes('3a')) ? true : null" (click)="addItems([['priests-pack', 1]]); updateSelected('3a')">
         <label for="3a">(a) A priest's pack</label><br>
 
-        <input type="radio" id="3b" name="classEquipment3" value="3b" (click)="addItems([['explorers-pack', 1]])">
+        <input type="radio" id="3b" name="classEquipment3" value="3b" 
+            [attr.checked]="(chosenOptions.includes('3b')) ? true : null" (click)="addItems([['explorers-pack', 1]]); updateSelected('3b')">
         <label for="3b">(b) An explorer's pack</label><br>
     </div>
 
     <div>
-        <input type="radio" id="4a" name="classEquipment4" value="4a"> <!--EQUIPMENT TYPE SELECTOR-->
-        <label for="4a">A holy symbol</label><br>
+        <label for="paladin-holySymbol">A holy symbol: </label>
+        <select name="paladin-holySymbol" id="paladin-holySymbol" (change)="addItemsFromSelect('paladin-holySymbol')">
+            <option selected value="none">Select</option>
+            <option *ngFor="let item of holy_symbols" [value]="item[0]">{{item[1]}}</option>
+        </select>
     </div>
 </div>
 
-<div *ngIf="startingClass == 'ranger' && currentChar.startingEquipmentSelected == false">
+<div *ngIf="startingClass == 'ranger' && currentChar.startingEquipmentSelected == false" class="container">
     <h4>Starting Equipment:</h4>
 
     <ul>
@@ -272,31 +416,49 @@
     <p>Choose between...</p>
 
     <div>
-        <input type="radio" id="1a" name="classEquipment1" value="1a" (click)="addItems([['scale-mail', 1]])">
+        <input type="radio" id="1a" name="classEquipment1" value="1a" 
+            [attr.checked]="(chosenOptions.includes('1a')) ? true : null" (click)="addItems([['scale-mail', 1]]); updateSelected('1a')">
         <label for="1a">(a) Scale mail</label><br>
 
-        <input type="radio" id="1b" name="classEquipment1" value="1b" (click)="addItems([['leather-armor', 1]])">
+        <input type="radio" id="1b" name="classEquipment1" value="1b" 
+            [attr.checked]="(chosenOptions.includes('1b')) ? true : null" (click)="addItems([['leather-armor', 1]]); updateSelected('1b')">
         <label for="1b">(b) Leather armor</label><br>
     </div>
 
     <div>
-        <input type="radio" id="2a" name="classEquipment2" value="2a" (click)="addItems([['shortsword', 2]])">
+        <input type="radio" id="2a" name="classEquipment2" value="2a" 
+            [attr.checked]="(chosenOptions.includes('2a')) ? true : null" (click)="addItems([['shortsword', 2]]); updateSelected('2a')">
         <label for="2a">(a) 2 shortswords</label><br>
 
-        <input type="radio" id="2b" name="classEquipment2" value="2b" (click)="addItems([['club', 2]])"> <!--EQUIPMENT TYPE SELECTOR-->
+        <input type="radio" id="2b" name="classEquipment2" value="2b" 
+            [attr.checked]="(chosenOptions.includes('2b')) ? true : null" (click)="revealCategory('ranger-2b'); updateSelected('2b')">
         <label for="2b">(b) 2 simple melee weapons</label><br>
+
+        <div id="ranger-2b" style="display: none">
+            <select name="ranger-2b-1" id="ranger-2b-1" (change)="addItemsFromSelect('ranger-2b-1')">
+                <option selected value="none">Select</option>
+                <option *ngFor="let item of simple_melee_weapons" [value]="item[0]">{{item[1]}}</option>
+            </select>
+
+            <select name="ranger-2b-2" id="ranger-2b-2" (change)="addItemsFromSelect('ranger-2b-2')">
+                <option selected value="none">Select</option>
+                <option *ngFor="let item of simple_melee_weapons" [value]="item[0]">{{item[1]}}</option>
+            </select>
+        </div>
     </div>
 
     <div>
-        <input type="radio" id="3a" name="classEquipment3" value="3a" (click)="addItems([['dungeoneers-pack', 1]])">
+        <input type="radio" id="3a" name="classEquipment3" value="3a" 
+            [attr.checked]="(chosenOptions.includes('3a')) ? true : null" (click)="addItems([['dungeoneers-pack', 1]]); updateSelected('3a')">
         <label for="3a">(a) A dungeoneer's pack</label><br>
 
-        <input type="radio" id="3b" name="classEquipment3" value="3b" (click)="addItems([['explorers-pack', 1]])">
+        <input type="radio" id="3b" name="classEquipment3" value="3b" 
+            [attr.checked]="(chosenOptions.includes('3b')) ? true : null" (click)="addItems([['explorers-pack', 1]]); updateSelected('3b')">
         <label for="3b">(b) An explorer's pack</label><br>
     </div>
 </div>
 
-<div *ngIf="startingClass == 'rogue' && currentChar.startingEquipmentSelected == false">
+<div *ngIf="startingClass == 'rogue' && currentChar.startingEquipmentSelected == false" class="container">
     <h4>Starting Equipment:</h4>
 
     <ul>
@@ -308,34 +470,41 @@
     <p>Choose between...</p>
 
     <div>
-        <input type="radio" id="1a" name="classEquipment1" value="1a" (click)="addItems([['rapier', 1]])">
+        <input type="radio" id="1a" name="classEquipment1" value="1a" 
+            [attr.checked]="(chosenOptions.includes('1a')) ? true : null" (click)="addItems([['rapier', 1]]); updateSelected('1a')">
         <label for="1a">(a) A rapier</label><br>
 
-        <input type="radio" id="1b" name="classEquipment1" value="1b" (click)="addItems([['shortsword', 1]])">
+        <input type="radio" id="1b" name="classEquipment1" value="1b" 
+            [attr.checked]="(chosenOptions.includes('1b')) ? true : null" (click)="addItems([['shortsword', 1]]); updateSelected('1b')">
         <label for="1b">(b) A shortsword</label><br>
     </div>
 
     <div>
-        <input type="radio" id="2a" name="classEquipment2" value="2a" (click)="addItems([['shortbow', 1], ['arrow', 20]])">
+        <input type="radio" id="2a" name="classEquipment2" value="2a" 
+            [attr.checked]="(chosenOptions.includes('2a')) ? true : null" (click)="addItems([['shortbow', 1], ['arrow', 20]]); updateSelected('2a')">
         <label for="2a">(a) A shortbow and quiver of 20 arrows</label><br>
 
-        <input type="radio" id="2b" name="classEquipment2" value="2b" (click)="addItems([['shortsword', 1]])">
+        <input type="radio" id="2b" name="classEquipment2" value="2b" 
+            [attr.checked]="(chosenOptions.includes('2b')) ? true : null" (click)="addItems([['shortsword', 1]]); updateSelected('2b')">
         <label for="2b">(b) A shortsword</label><br>
     </div>
 
     <div>
-        <input type="radio" id="3a" name="classEquipment3" value="3a" (click)="addItems([['burglars-pack', 1]])">
+        <input type="radio" id="3a" name="classEquipment3" value="3a" 
+            [attr.checked]="(chosenOptions.includes('3a')) ? true : null" (click)="addItems([['burglars-pack', 1]]); updateSelected('3a')">
         <label for="3a">(a) A burglar's pack</label><br>
 
-        <input type="radio" id="3b" name="classEquipment3" value="3b" (click)="addItems([['dungeoneers-pack', 1]])">
+        <input type="radio" id="3b" name="classEquipment3" value="3b" 
+            [attr.checked]="(chosenOptions.includes('3b')) ? true : null" (click)="addItems([['dungeoneers-pack', 1]]); updateSelected('3b')">
         <label for="3b">(b) A dungeoneer's pack</label><br>
 
-        <input type="radio" id="3c" name="classEquipment3" value="3c" (click)="addItems([['explorers-pack', 1]])">
+        <input type="radio" id="3c" name="classEquipment3" value="3c" 
+            [attr.checked]="(chosenOptions.includes('3c')) ? true : null" (click)="addItems([['explorers-pack', 1]]); updateSelected('3c')">
         <label for="3c">(c) An explorer's pack</label><br>
     </div>
 </div>
 
-<div *ngIf="startingClass == 'sorcerer' && currentChar.startingEquipmentSelected == false">
+<div *ngIf="startingClass == 'sorcerer' && currentChar.startingEquipmentSelected == false" class="container">
     <h4>Starting Equipment:</h4>
 
     <ul>
@@ -345,31 +514,51 @@
     <p>Choose between...</p>
 
     <div>
-        <input type="radio" id="1a" name="classEquipment1" value="1a" (click)="addItems([['crossbow-light', 1], ['crossbow-bolt', 20]])">
+        <input type="radio" id="1a" name="classEquipment1" value="1a" 
+            [attr.checked]="(chosenOptions.includes('1a')) ? true : null" (click)="addItems([['crossbow-light', 1], ['crossbow-bolt', 20]]); updateSelected('1a')">
         <label for="1a">(a) A light crossbow and 20 bolts</label><br>
 
-        <input type="radio" id="1b" name="classEquipment1" value="1b" (click)="addItems([['club', 1]])"> <!--EQUIPMENT TYPE SELECTOR-->
+        <input type="radio" id="1b" name="classEquipment1" value="1b" 
+            [attr.checked]="(chosenOptions.includes('1b')) ? true : null" (click)="revealCategory('sorcerer-1b'); updateSelected('1b')">
         <label for="1b">(b) Any simple weapon</label><br>
+
+        <div id="sorcerer-1b" style="display: none">
+            <select name="sorcerer-1b-1" id="sorcerer-1b-1" (change)="addItemsFromSelect('sorcerer-1b-1')">
+                <option selected value="none">Select</option>
+                <option *ngFor="let item of simple_weapons" [value]="item[0]">{{item[1]}}</option>
+            </select>
+        </div>
     </div>
 
     <div>
-        <input type="radio" id="2a" name="classEquipment2" value="2a" (click)="addItems([['component-pouch', 1]])">
+        <input type="radio" id="2a" name="classEquipment2" value="2a" 
+            [attr.checked]="(chosenOptions.includes('2a')) ? true : null" (click)="addItems([['component-pouch', 1]]); updateSelected('2a')">
         <label for="2a">(a) A component pouch</label><br>
 
-        <input type="radio" id="2b" name="classEquipment2" value="2b" (click)="addItems([['orb', 1]])"> <!--EQUIPMENT TYPE SELECTOR-->
+        <input type="radio" id="2b" name="classEquipment2" value="2b" 
+            [attr.checked]="(chosenOptions.includes('2b')) ? true : null" (click)="revealCategory('sorcerer-2b'); updateSelected('2b')">
         <label for="2b">(b) An arcane focus</label><br>
+
+        <div id="sorcerer-2b" style="display: none">
+            <select name="sorcerer-2b-1" id="sorcerer-2b-1" (change)="addItemsFromSelect('sorcerer-2b-1')">
+                <option selected value="none">Select</option>
+                <option *ngFor="let item of arcane_foci" [value]="item[0]">{{item[1]}}</option>
+            </select>
+        </div>
     </div>
 
     <div>
-        <input type="radio" id="3a" name="classEquipment3" value="3a" (click)="addItems([['dungeoneers-pack', 1]])">
+        <input type="radio" id="3a" name="classEquipment3" value="3a" 
+            [attr.checked]="(chosenOptions.includes('3a')) ? true : null" (click)="addItems([['dungeoneers-pack', 1]]); updateSelected('3a')">
         <label for="3a">(a) A dungeoneer's pack</label><br>
 
-        <input type="radio" id="3b" name="classEquipment3" value="3b" (click)="addItems([['explorers-pack', 1]])">
+        <input type="radio" id="3b" name="classEquipment3" value="3b" 
+            [attr.checked]="(chosenOptions.includes('3b')) ? true : null" (click)="addItems([['explorers-pack', 1]]); updateSelected('3b')">
         <label for="3b">(b) An explorer's pack</label><br>
     </div>
 </div>
 
-<div *ngIf="startingClass == 'warlock' && currentChar.startingEquipmentSelected == false">
+<div *ngIf="startingClass == 'warlock' && currentChar.startingEquipmentSelected == false" class="container">
     <h4>Starting Equipment:</h4>
 
     <ul>
@@ -380,36 +569,59 @@
     <p>Choose between...</p>
 
     <div>
-        <input type="radio" id="1a" name="classEquipment1" value="1a" (click)="addItems([['crossbow-light', 1], ['crossbow-bolt', 20]])">
+        <input type="radio" id="1a" name="classEquipment1" value="1a" 
+            [attr.checked]="(chosenOptions.includes('1a')) ? true : null" (click)="addItems([['crossbow-light', 1], ['crossbow-bolt', 20]]); updateSelected('1a')">
         <label for="1a">(a) A light crossbow and 20 bolts</label><br>
 
-        <input type="radio" id="1b" name="classEquipment1" value="1b" (click)="addItems([['club', 1]])"> <!--EQUIPMENT TYPE SELECTOR-->
+        <input type="radio" id="1b" name="classEquipment1" value="1b" 
+            [attr.checked]="(chosenOptions.includes('1b')) ? true : null" (click)="revealCategory('warlock-1b'); updateSelected('1b')">
         <label for="1b">(b) Any simple weapon</label><br>
+
+        <div id="warlock-1b" style="display: none">
+            <select name="warlock-1b-1" id="warlock-1b-1" (change)="addItemsFromSelect('warlock-1b-1')">
+                <option selected value="none">Select</option>
+                <option *ngFor="let item of simple_weapons" [value]="item[0]">{{item[1]}}</option>
+            </select>
+        </div>
     </div>
 
     <div>
-        <input type="radio" id="2a" name="classEquipment2" value="2a" (click)="addItems([['component-pouch', 1]])">
+        <input type="radio" id="2a" name="classEquipment2" value="2a" 
+            [attr.checked]="(chosenOptions.includes('2a')) ? true : null" (click)="addItems([['component-pouch', 1]]); updateSelected('2a')">
         <label for="2a">(a) A component pouch</label><br>
 
-        <input type="radio" id="2b" name="classEquipment2" value="2b" (click)="addItems([['orb', 1]])"> <!--EQUIPMENT TYPE SELECTOR-->
+        <input type="radio" id="2b" name="classEquipment2" value="2b" 
+            [attr.checked]="(chosenOptions.includes('2b')) ? true : null" (click)="revealCategory('warlock-2b'); updateSelected('2b')">
         <label for="2b">(b) An arcane focus</label><br>
+
+        <div id="warlock-2b" style="display: none">
+            <select name="warlock-2b-1" id="warlock-2b-1" (change)="addItemsFromSelect('warlock-2b-1')">
+                <option selected value="none">Select</option>
+                <option *ngFor="let item of arcane_foci" [value]="item[0]">{{item[1]}}</option>
+            </select>
+        </div>
     </div>
 
     <div>
-        <input type="radio" id="3a" name="classEquipment3" value="3a" (click)="addItems([['scholars-pack', 1]])">
+        <input type="radio" id="3a" name="classEquipment3" value="3a" 
+            [attr.checked]="(chosenOptions.includes('3a')) ? true : null" (click)="addItems([['scholars-pack', 1]]); updateSelected('3a')">
         <label for="3a">(a) A scholar's pack</label><br>
 
-        <input type="radio" id="3b" name="classEquipment3" value="3b" (click)="addItems([['dungeoneers-pack', 1]])">
+        <input type="radio" id="3b" name="classEquipment3" value="3b" 
+            [attr.checked]="(chosenOptions.includes('3b')) ? true : null" (click)="addItems([['dungeoneers-pack', 1]]); updateSelected('3b')">
         <label for="3b">(b) A dungeoneer's pack</label><br>
     </div>
 
     <div>
-        <input type="radio" id="4a" name="classEquipment4" value="4a" (click)="addItems([['club', 1]])"> <!--EQUIPMENT TYPE SELECTOR-->
-        <label for="4a">Any simple weapon</label><br>
+        <label for="warlock-simpleWeapon">Any simple weapon: </label>
+        <select name="warlock-simpleWeapon" id="warlock-simpleWeapon" (change)="addItemsFromSelect('warlock-simpleWeapon')">
+            <option selected value="none">Select</option>
+            <option *ngFor="let item of simple_weapons" [value]="item[0]">{{item[1]}}</option>
+        </select>
     </div>
 </div>
 
-<div *ngIf="startingClass == 'wizard' && currentChar.startingEquipmentSelected == false">
+<div *ngIf="startingClass == 'wizard' && currentChar.startingEquipmentSelected == false" class="container">
     <h4>Starting Equipment:</h4>
 
     <ul>
@@ -419,26 +631,39 @@
     <p>Choose between...</p>
 
     <div>
-        <input type="radio" id="1a" name="classEquipment1" value="1a" (click)="addItems([['quarterstaff', 1]])">
+        <input type="radio" id="1a" name="classEquipment1" value="1a" 
+            [attr.checked]="(chosenOptions.includes('1a')) ? true : null" (click)="addItems([['quarterstaff', 1]]); updateSelected('1a')">
         <label for="1a">(a) A quarterstaff</label><br>
 
-        <input type="radio" id="1b" name="classEquipment1" value="1b" (click)="addItems([['dagger', 1]])">
+        <input type="radio" id="1b" name="classEquipment1" value="1b" 
+            [attr.checked]="(chosenOptions.includes('1b')) ? true : null" (click)="addItems([['dagger', 1]]); updateSelected('1b')">
         <label for="1b">(b) A dagger</label><br>
     </div>
 
     <div>
-        <input type="radio" id="2a" name="classEquipment2" value="2a" (click)="addItems([['component-pouch', 1]])">
+        <input type="radio" id="2a" name="classEquipment2" value="2a" 
+            [attr.checked]="(chosenOptions.includes('2a')) ? true : null" (click)="addItems([['component-pouch', 1]]); updateSelected('2a')">
         <label for="2a">(a) A component pouch</label><br>
 
-        <input type="radio" id="2b" name="classEquipment2" value="2b" (click)="addItems([['orb', 1]])"> <!--EQUIPMENT TYPE SELECTOR-->
+        <input type="radio" id="2b" name="classEquipment2" value="2b" 
+            [attr.checked]="(chosenOptions.includes('2b')) ? true : null" (click)="revealCategory('wizard-2b'); updateSelected('2b')">
         <label for="2b">(b) An arcane focus</label><br>
+
+        <div id="wizard-2b" style="display: none">
+            <select name="wizard-2b-1" id="wizard-2b-1" (change)="addItemsFromSelect('wizard-2b-1')">
+                <option selected value="none">Select</option>
+                <option *ngFor="let item of arcane_foci" [value]="item[0]">{{item[1]}}</option>
+            </select>
+        </div>
     </div>
 
     <div>
-        <input type="radio" id="3a" name="classEquipment3" value="3a" (click)="addItems([['scholars-pack', 1]])">
+        <input type="radio" id="3a" name="classEquipment3" value="3a" 
+            [attr.checked]="(chosenOptions.includes('3a')) ? true : null" (click)="addItems([['scholars-pack', 1]]); updateSelected('3a')">
         <label for="3a">(a) A scholar's pack</label><br>
 
-        <input type="radio" id="3b" name="classEquipment3" value="3b" (click)="addItems([['explorers-pack', 1]])">
+        <input type="radio" id="3b" name="classEquipment3" value="3b" 
+            [attr.checked]="(chosenOptions.includes('3b')) ? true : null" (click)="addItems([['explorers-pack', 1]]); updateSelected('3b')">
         <label for="3b">(b) An explorer's pack</label><br>
     </div>
 </div>
@@ -450,7 +675,7 @@
 <br><br>
 
 <h4>Manage Inventory</h4>
-<div class="grid" *ngFor="let item of charItems">
+<div class="grid" *ngFor="let item of charItems" style="width: 30%;">
     <p>{{item}}</p>
     <button type="button">Remove</button>
 </div>
@@ -458,6 +683,6 @@
 <h4>Add Items</h4>
 <label for="search">Item Search: </label>
 <input type="text" id="search" name="search">
-<div>
+<div style="width: 30%;">
     <p>Results: </p>
 </div>

--- a/src/app/char-creation-equipment-tab/char-creation-equipment-tab.component.ts
+++ b/src/app/char-creation-equipment-tab/char-creation-equipment-tab.component.ts
@@ -18,16 +18,26 @@ export class CharCreationEquipmentTabComponent implements OnInit {
 
   currentChar: charObject = new charObject;
 
+  startingClass?: string;
+
   charItems = [
     "item1", "item2", "item3"
   ];
 
-  threeB: boolean = false;
+  chosenOptions: string[] = [];
 
-  holy_symbols: string[][] = [['amulet', 'Amulet'], ['emblem', 'Emblem'], ['reliquary', 'Reliquary']];
-  simple_weapons: string[][] = [['club', 'Club'], ['dagger', 'Dagger'], ['greatclub', 'Greatclub']];
+  arcane_foci: string[][] = [];
+  druidic_foci: string[][] = [];
+  holy_symbols: string[][] = []; //[['amulet', 'Amulet'], ['emblem', 'Emblem'], ['reliquary', 'Reliquary']];
+  martial_weapons: string[][] = [];
+  martial_melee_weapons: string[][] = [];
+  musical_instruments: string[][] = [];
+  simple_weapons: string[][] = [];
+  simple_melee_weapons: string[][] = [];
 
   //event emitter shenanigans
+  //indicates whether the equipment tab is considered "complete" for the purpose of the "finish and view character" button appearing
+  //conditions to be met: character has at least one item
   updateCompletedStatus() {
     if(this.currentChar.inventoryItemsIndexes.length > 0) {
       this.completionUpdater.emit([4, true]);
@@ -37,6 +47,7 @@ export class CharCreationEquipmentTabComponent implements OnInit {
     }
   }
 
+  //adds each item to the character object the specified amount of times
   addItems(itemsArray: any[][]) {
     itemsArray.forEach(element => {
       for(let i=0; i < element[1]; i++) {
@@ -50,21 +61,14 @@ export class CharCreationEquipmentTabComponent implements OnInit {
     this.updateCompletedStatus();
   }
 
-  startingClass?: string;
+  //locates the specified select dropdown, and adds the selected item to the character object
+  addItemsFromSelect(htmlId: string) {
+    let temp: any[][] = [[(document.getElementById(htmlId) as HTMLSelectElement)?.value, 1]];
 
-  equipmentCategoryBreakdown(categoryName: string, arrayToEdit: string[][]) {
-    let tempArray: string[][] = [];
-
-    this.dndApiService.EquipmentCategoryData(categoryName).subscribe((catData) => {
-      catData.equipment.forEach((item: any) => {
-        tempArray.push([item.index, item.name]);
-      });;
-
-      arrayToEdit = tempArray;
-      console.log(arrayToEdit);
-    });
+    this.addItems(temp);
   }
 
+  //adds a set of "default" items to the character's inventory (depending on the character's class)
   addDefaultItems(className: string) {
     switch(className) {
       case 'barbarian': {
@@ -117,9 +121,33 @@ export class CharCreationEquipmentTabComponent implements OnInit {
     }
   }
 
+  //displays the specified section
+  revealCategory(hiddenSelectID: string) {
+    (document.getElementById(hiddenSelectID) as HTMLSelectElement).style.display = "block";
+  }
+
+  //updates the "startingEquipmentOptions" array (which stores user selections so they can be re-checked on component reload)
+  updateSelected(newSelection: string) {
+    this.chosenOptions.push(newSelection);
+
+    sessionStorage.setItem('startingEquipmentOptions', JSON.stringify(this.chosenOptions));
+  }
+
+  //takes in the current character object and determines the character's "starting class"
+  //distributes "default" starting items, if they haven't yet been received
+  //stores previous starting equipment selections, if they exist
+  //collects and stores item lists from relevant equipment categories
   ngOnInit(): void {
     this.currentChar = JSON.parse(String(sessionStorage.getItem('currentChar')));
     console.log(this.currentChar);
+
+    if(sessionStorage.getItem('startingEquipmentOptions') == null) {
+      sessionStorage.setItem('startingEquipmentOptions', JSON.stringify([]));
+    }
+    else{
+      this.chosenOptions = JSON.parse(String(sessionStorage.getItem('startingEquipmentOptions')));
+      console.log(this.chosenOptions);
+    }
 
 
     if(this.currentChar.classes.length > 0) {
@@ -129,6 +157,62 @@ export class CharCreationEquipmentTabComponent implements OnInit {
         this.addDefaultItems(this.startingClass);
         this.currentChar.defaultStartingEquipmentCollected = true;
         sessionStorage.setItem('currentChar', JSON.stringify(this.currentChar));
+
+        this.dndApiService.EquipmentCategoryData('arcane-foci').subscribe((data) => {
+          let results = data.equipment;
+          results.forEach((element: any) => {
+            this.arcane_foci.push([element.index, element.name]);
+          });
+        });
+
+        this.dndApiService.EquipmentCategoryData('druidic-foci').subscribe((data) => {
+          let results = data.equipment;
+          results.forEach((element: any) => {
+            this.druidic_foci.push([element.index, element.name]);
+          });
+        });
+
+        this.dndApiService.EquipmentCategoryData('holy-symbols').subscribe((data) => {
+          let results = data.equipment;
+          results.forEach((element: any) => {
+            this.holy_symbols.push([element.index, element.name]);
+          });
+        });
+
+        this.dndApiService.EquipmentCategoryData('martial-weapons').subscribe((data) => {
+          let results = data.equipment;
+          results.forEach((element: any) => {
+            this.martial_weapons.push([element.index, element.name]);
+          });
+        });
+
+        this.dndApiService.EquipmentCategoryData('martial-melee-weapons').subscribe((data) => {
+          let results = data.equipment;
+          results.forEach((element: any) => {
+            this.martial_melee_weapons.push([element.index, element.name]);
+          });
+        });
+
+        this.dndApiService.EquipmentCategoryData('musical-instruments').subscribe((data) => {
+          let results = data.equipment;
+          results.forEach((element: any) => {
+            this.musical_instruments.push([element.index, element.name]);
+          });
+        });
+
+        this.dndApiService.EquipmentCategoryData('simple-weapons').subscribe((data) => {
+          let results = data.equipment;
+          results.forEach((element: any) => {
+            this.simple_weapons.push([element.index, element.name]);
+          });
+        });
+
+        this.dndApiService.EquipmentCategoryData('simple-melee-weapons').subscribe((data) => {
+          let results = data.equipment;
+          results.forEach((element: any) => {
+            this.simple_melee_weapons.push([element.index, element.name]);
+          });
+        });
       }
       
     }

--- a/src/app/char-creation-nrb-tab/char-creation-nrb-tab.component.html
+++ b/src/app/char-creation-nrb-tab/char-creation-nrb-tab.component.html
@@ -26,7 +26,7 @@
         <h4>Select {{raceUserAbilitiesCount}} ability bonuse(s):</h4>
 
         <div *ngFor="let ability of raceUserAbilities">
-            <input type="checkbox" value={{ability[0]}} id="abilityScoreOptions" (click)="updateRaceAbilityBonuses(ability[0], ability[2])">
+            <input type="checkbox" [attr.checked]="(nrbCheckboxes(ability[0], currentChar.race.chosenAbilityBonuses)) ? true : null" value={{ability[0]}} id="abilityScoreOptions" (click)="updateRaceAbilityBonuses(ability[0], ability[2])">
             <label for="abilityScoreOptions">Increase {{ability[1]}} by {{ability[2]}}</label><br>
         </div>
     </div>
@@ -35,16 +35,16 @@
         <h4>Select {{raceUserProficienciesCount}} proficiencie(s):</h4>
 
         <div *ngFor="let proficiency of raceUserProficiencies">
-            <input type="checkbox" value={{proficiency[0]}} id="proficiencyOptions" (click)="updateRaceProficiencies(proficiency[0], proficiency[1])">
+            <input type="checkbox" [attr.checked]="(nrbCheckboxes(proficiency[0], currentChar.race.chosenProficiencyIndex)) ? true : null" value={{proficiency[0]}} id="proficiencyOptions" (click)="updateRaceProficiencies(proficiency[0], proficiency[1])">
             <label for="proficiencyOptions">Become proficient in {{proficiency[1]}}</label><br>
         </div>
     </div>
 
-    <div class="container" *ngIf="raceUserLanguages != null">
+    <div class="container" *ngIf="raceUserLanguagesData != null">
         <h4>Select {{raceUserLanguagesCount}} language(s):</h4>
 
         <div *ngFor="let language of raceUserLanguages">
-            <input type="checkbox" value={{language[0]}} id="languageOptions" (click)="updateRaceLanguages(language[0], language[1])">
+            <input type="checkbox" [attr.checked]="(nrbCheckboxes(language[0], currentChar.race.chosenLanguageIndex)) ? true : null" value={{language[0]}} id="languageOptions" (click)="updateRaceLanguages(language[0], language[1])">
             <label for="languageOptions">Learn {{language[1]}}</label><br>
         </div>
     </div>
@@ -85,7 +85,7 @@
         <h4>Select {{backgroundUserLanguagesCount}} language(s):</h4>
 
         <div *ngFor="let language of backgroundLanguageList">
-            <input type="checkbox" value={{language[0]}} id="languageOptions" (click)="updateBackgroundLanguage(language[0], language[1])">
+            <input type="checkbox" [attr.checked]="(nrbCheckboxes(language[0], currentChar.background.chosenLanguageIndexes)) ? true : null"  value={{language[0]}} id="languageOptions" (click)="updateBackgroundLanguage(language[0], language[1])">
             <label for="languageOptions">Learn {{language[1]}}</label><br>
         </div>
     </div>

--- a/src/app/char-creation-personality-tab/char-creation-personality-tab.component.html
+++ b/src/app/char-creation-personality-tab/char-creation-personality-tab.component.html
@@ -19,15 +19,7 @@
 
 <br><br>
 
-<p>Personality Traits</p>
-<input type="checkbox" id="sampleTrait1" name="sampleTrait1" value="trait1">
-  <label for="sampleTrait1"> Sample Personality Trait 1</label><br>
-<input type="checkbox" id="sampleTrait2" name="sampleTrait2" value="trait2">
-  <label for="sampleTrait2"> Sample Personality Trait 2</label><br>
-<input type="checkbox" id="sampleTrait3" name="sampleTrait3" value="trait3">
-  <label for="sampleTrait3"> Sample Personality Trait 3</label><br>
-  
-<label for="userTrait">Additional Trait(s): </label>
+<p>Personality Traits: </p>
 <input type="text" id="userTrait" name="userTrait" (change)="updateTraits()">
 
 
@@ -35,16 +27,7 @@
 <br><br>
 
 
-
-<p>Ideals</p>
-<input type="checkbox" id="sampleIdeal1" name="sampleIdeal1" value="ideal1">
-  <label for="sampleIdeal1"> Sample Ideal 1</label><br>
-<input type="checkbox" id="sampleIdeal2" name="sampleIdeal2" value="ideal2">
-  <label for="sampleIdeal2"> Sample Ideal 2</label><br>
-<input type="checkbox" id="sampleIdeal3" name="sampleIdeal3" value="ideal3">
-  <label for="sampleIdeal3"> Sample Ideal 3</label><br>
-
-<label for="userIdeal">Additional Ideal(s): </label>
+<p >Ideals: </p>
 <input type="text" id="userIdeal" name="userIdeal" (change)="updateIdeals()">
   
 
@@ -53,15 +36,7 @@
 
 
 
-<p>Bonds</p>
-<input type="checkbox" id="sampleBond1" name="sampleBond1" value="bond1">
-  <label for="sampleBond1"> Sample Bond 1</label><br>
-<input type="checkbox" id="sampleBond2" name="sampleBond2" value="bond2">
-  <label for="sampleBond2"> Sample Bond 2</label><br>
-<input type="checkbox" id="sampleBond3" name="sampleBond3" value="bond3">
-  <label for="sampleBond3"> Sample Bond 3</label><br>
-  
-<label for="userBond">Additional Bond(s): </label>
+<p>Bonds: </p>
 <input type="text" id="userBond" name="userBond" (change)="updateBonds()">
 
 
@@ -70,13 +45,6 @@
 
 
 
-<p>Flaws</p>
-<input type="checkbox" id="sampleFlaw1" name="sampleFlaw1" value="flaw1">
-  <label for="sampleFlaw1"> Sample Flaw 1</label><br>
-<input type="checkbox" id="sampleFlaw2" name="sampleFlaw2" value="flaw2">
-  <label for="sampleFlaw2"> Sample Flaw 2</label><br>
-<input type="checkbox" id="sampleFlaw3" name="sampleFlaw3" value="flaw3">
-  <label for="sampleFlaw3"> Sample Flaw 3</label><br>
+<p>Flaws: </p>
   
-<label for="userFlaw">Additional Flaw(s): </label>
 <input type="text" id="userFlaw" name="userFlaw" (change)="updateFlaws()">

--- a/src/app/char-creation-personality-tab/char-creation-personality-tab.component.ts
+++ b/src/app/char-creation-personality-tab/char-creation-personality-tab.component.ts
@@ -13,6 +13,8 @@ export class CharCreationPersonalityTabComponent implements OnInit {
 
   currentChar: charObject = new charObject;
 
+  //updates the character's alignment (in the char's personality object)
+  //creates a new personality object if it doesn't already exist
   updateAlignment() {
     if(this.currentChar.personality == null) {
       this.currentChar.personality = new personalityObject;
@@ -24,6 +26,8 @@ export class CharCreationPersonalityTabComponent implements OnInit {
     sessionStorage.setItem('currentChar', JSON.stringify(this.currentChar));
   }
 
+  //updates the character's personality traits (in the char's personality object)
+  //creates a new personality object if it doesn't already exist
   updateTraits() {
     if(this.currentChar.personality == null) {
       this.currentChar.personality = new personalityObject;
@@ -35,6 +39,8 @@ export class CharCreationPersonalityTabComponent implements OnInit {
     sessionStorage.setItem('currentChar', JSON.stringify(this.currentChar));
   }
 
+  //updates the character's ideals (in the char's personality object)
+  //creates a new personality object if it doesn't already exist
   updateIdeals() {
     if(this.currentChar.personality == null) {
       this.currentChar.personality = new personalityObject;
@@ -46,6 +52,8 @@ export class CharCreationPersonalityTabComponent implements OnInit {
     sessionStorage.setItem('currentChar', JSON.stringify(this.currentChar));
   }
 
+  //updates the character's bonds (in the char's personality object)
+  //creates a new personality object if it doesn't already exist
   updateBonds() {
     if(this.currentChar.personality == null) {
       this.currentChar.personality = new personalityObject;
@@ -57,6 +65,8 @@ export class CharCreationPersonalityTabComponent implements OnInit {
     sessionStorage.setItem('currentChar', JSON.stringify(this.currentChar));
   }
 
+  //updates the character's flaws (in the char's personality object)
+  //creates a new personality object if it doesn't already exist
   updateFlaws() {
     if(this.currentChar.personality == null) {
       this.currentChar.personality = new personalityObject;
@@ -68,9 +78,35 @@ export class CharCreationPersonalityTabComponent implements OnInit {
     sessionStorage.setItem('currentChar', JSON.stringify(this.currentChar));
   }
 
+  //takes in the current character object, then (as applicable) populates viewable fields with existing character info
   ngOnInit(): void {
     this.currentChar = JSON.parse(String(sessionStorage.getItem('currentChar')));
     console.log(this.currentChar);
+
+    //populates fields if the info is already present in currentChar
+    //checks to make sure the info exists first to prevent nullpointerexception
+    if(this.currentChar.personality) {
+      if(this.currentChar.personality.alignmentIndex) {
+        (document.getElementById("alignment") as HTMLSelectElement).value = this.currentChar.personality.alignmentIndex;
+      }
+
+      if(this.currentChar.personality.personalityTraits) {
+        (document.getElementById("userTrait") as HTMLInputElement).value = this.currentChar.personality.personalityTraits;
+      }
+
+      if(this.currentChar.personality.ideals) {
+        (document.getElementById("userIdeal") as HTMLInputElement).value = this.currentChar.personality.ideals;
+      }
+
+      if(this.currentChar.personality.bonds) {
+        (document.getElementById("userBond") as HTMLInputElement).value = this.currentChar.personality.bonds;
+      }
+
+      if(this.currentChar.personality.flaws) {
+        (document.getElementById("userFlaw") as HTMLInputElement).value = this.currentChar.personality.flaws;
+      }
+    }
+    
   }
 
 }

--- a/src/app/char-creation-spells-tab/char-creation-spells-tab.component.html
+++ b/src/app/char-creation-spells-tab/char-creation-spells-tab.component.html
@@ -8,7 +8,7 @@
         <p>Max Learned Cantrips: {{cast.cantripsKnownCount}}</p> <br>
 
         <div *ngFor="let cantrip of cast.cantripsList">
-            <input type="checkbox" value={{cantrip[0]}} id="cantrips" (click)="updateCantrips(cast.classIndex, cantrip[0], cantrip[1])">
+            <input type="checkbox" [attr.checked]="(spellCheckboxes(cantrip[0], false, cast.classIndex)) ? true : null" value={{cantrip[0]}} id="cantrips" (click)="updateCantrips(cast.classIndex, cantrip[0], cantrip[1])">
             <label for="cantrips">{{cantrip[1]}}</label><br>
         </div>
     </div>
@@ -19,7 +19,7 @@
             <p>Spell Slots: {{level}}</p> <br>
 
             <div *ngFor="let spell of cast.spellsByLevel[i]">
-                <input type="checkbox" value={{spell[0]}} id="leveledSpells" (click)="updateLeveledSpells(cast.classIndex, spell[0], spell[1])">
+                <input type="checkbox" [attr.checked]="(spellCheckboxes(spell[0], true, cast.classIndex)) ? true : null" value={{spell[0]}} id="leveledSpells" (click)="updateLeveledSpells(cast.classIndex, spell[0], spell[1])">
                 <label for="leveledSpells">{{spell[1]}}</label><br>
             </div>
         </div>

--- a/src/app/char-creation-stats-tab/char-creation-stats-tab.component.html
+++ b/src/app/char-creation-stats-tab/char-creation-stats-tab.component.html
@@ -28,7 +28,7 @@
 
     <div class="statblock" *ngFor="let stat of stats, index as i">
         <label>{{stat}}</label>
-        <input type="text" id="manualEntry{{i}}" [(ngModel)]="enteredStats[i]" (change)="updateStat(i)">
+        <input type="text" id="manualEntry{{i}}" (change)="updateStat(i)" value="{{currentChar.abilityScores[i]}}">
     </div>
 </div>
 

--- a/src/app/char-creation-stats-tab/char-creation-stats-tab.component.ts
+++ b/src/app/char-creation-stats-tab/char-creation-stats-tab.component.ts
@@ -34,11 +34,11 @@ export class CharCreationStatsTabComponent implements OnInit {
   stats = ["Str", "Dex", "Con", "Int", "Wis", "Cha"];
   standardArraySet = [15, 14, 13, 12, 10, 8];
 
-  enteredStats = [0,0,0,0,0,0];
-
   pointBuyPoints = 27;
 
   //event emitter shenanigans
+  //indicates whether the stats tab is considered "complete" for the purpose of the "finish and view character" button appearing
+  //conditions to be met: all ability scores have been modified (have a nonzero value)
   updateCompletedStatus() {
     if(this.currentChar.abilityScores.includes(0) == false) {
       this.completionUpdater.emit([2, true]);
@@ -48,6 +48,7 @@ export class CharCreationStatsTabComponent implements OnInit {
     }
   }
 
+  //changes the ability score (corresponding to the passed-in index) on the character object
   updateStat(ind: number) {
     this.currentChar.abilityScores[ind] = Number((document.getElementById("manualEntry" + ind) as HTMLInputElement)?.value);
     console.log(this.currentChar);
@@ -57,6 +58,9 @@ export class CharCreationStatsTabComponent implements OnInit {
     sessionStorage.setItem('currentChar', JSON.stringify(this.currentChar));
   }
 
+  //used for displaying the currently chosen generation method / hiding the other two (done through *ngIf statements in the html)
+  //changes the "selected option" from the previously displayed generation method to the current one
+  //turns the previous generation method false, and the current one true
   newGenMethod() {
     switch(this.selectedOption) {
       case "standardArray": {
@@ -92,6 +96,7 @@ export class CharCreationStatsTabComponent implements OnInit {
     }
   }
 
+  //takes in the current character object
   ngOnInit(): void {
     this.currentChar = JSON.parse(String(sessionStorage.getItem('currentChar')));
     console.log(this.currentChar);

--- a/src/app/create-edit-page/backgroundObject.ts
+++ b/src/app/create-edit-page/backgroundObject.ts
@@ -1,5 +1,5 @@
 export class backgroundObject {
     backgroundIndex: string = '';
-    chosenLanguageIndexes?: string[][];
+    chosenLanguageIndexes: string[][] = [];
     chosenEquipmentIndexes?: string[];
 }

--- a/src/app/create-edit-page/classObject.ts
+++ b/src/app/create-edit-page/classObject.ts
@@ -4,7 +4,7 @@ import { subclassObject } from "./subclassObject";
 export class classObject {
     classIndex: string = '';
     classLevel: number = 1;
-    chosenProficiencyIndex?: string[][];
+    chosenProficiencyIndex: string[][] = [];
     chosenExpertisesIntex?: string[][];
 
     uniqueClassChoices?: string[][][];

--- a/src/app/create-edit-page/raceObject.ts
+++ b/src/app/create-edit-page/raceObject.ts
@@ -1,6 +1,6 @@
 export class raceObject {
     raceIndex: string = '';
-    chosenLanguageIndex?: string[][];
-    chosenProficiencyIndex?: string[][];
-    chosenAbilityBonuses?: any[][];
+    chosenLanguageIndex: string[][] = [];
+    chosenProficiencyIndex: string[][] = [];
+    chosenAbilityBonuses: any[][] = [];
 }

--- a/src/app/create-edit-page/spellcasterObject.ts
+++ b/src/app/create-edit-page/spellcasterObject.ts
@@ -2,10 +2,10 @@ export class spellCasterObject {
     spellCastingAbility: string = '';
 
     knowsCantrips: boolean = false;
-    cantripsKnown?: string[][];
+    cantripsKnown: string[][] = [];
 
     learnsSpells: boolean = false;
-    spellsKnown?: string[][];
+    spellsKnown: string[][] = [];
 
     preparesSpells: boolean = false;
     spellsPrepared?: string[][];

--- a/src/app/dnd-api-service.service.ts
+++ b/src/app/dnd-api-service.service.ts
@@ -45,6 +45,18 @@ export class DndApiServiceService {
     );
   }
 
+  ClassLevelsData(classIndex: string): Observable<any> {
+    return this.http.get(
+      'https://www.dnd5eapi.co/api/classes/' + classIndex + '/levels'
+    )
+  }
+
+  ClassFeatureData(featureName: string): Observable<any> {
+    return this.http.get(
+      'https://www.dnd5eapi.co/api/features/' + featureName
+    )
+  }
+
   EquipmentCategoryData(category: string): Observable<any> {
     return this.http.get(
       'https://www.dnd5eapi.co/api/equipment-categories/' + category


### PR DESCRIPTION
Existing user selections (like checked checkboxes) are also reapplied to the tab on component load Made class-based feature "offshoot" API calls
Allowed the class feature data to display to users Fixed spell additions only applying to character's first class, if multiclassed Made equipment tab item category dropdowns pull from API Made equipment tab item category dropdowns only appear once appropriate selection has been made by user Updated comments on the main ts files of each char creation tab component